### PR TITLE
Inspect Capture and More Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,78 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_size = 2
+
+[*.{cs,cpp,h,c,cc,cxx,hpp,hxx}]
+indent_size = 4
+
+[*.{cpp,h,c,cc,cxx,hpp,hxx}]
+cpp_indent_braces = false
+cpp_indent_multi_line_relative_to = statement_begin
+cpp_new_line_before_open_brace_namespace = new_line
+cpp_new_line_before_open_brace_type = new_line
+cpp_new_line_before_open_brace_function = new_line
+cpp_new_line_before_open_brace_block = new_line
+cpp_new_line_before_catch = true
+cpp_new_line_before_else = true
+cpp_new_line_before_finally = true
+cpp_space_before_function_open_parenthesis = false
+cpp_space_within_parameter_list_parentheses = true
+cpp_space_between_empty_parameter_list_parentheses = true
+cpp_space_after_keywords_in_control_flow_statements = true
+cpp_space_within_control_flow_statement_parentheses = true
+cpp_space_before_semicolon_in_for_statement = false
+cpp_space_after_semicolon_in_for_statement = true
+cpp_space_around_binary_operator = insert
+cpp_space_around_assignment_operator = insert
+
+[*.xaml]
+charset = utf-8-bom
+
+[*.cs]
+charset = utf-8-bom
+# New line settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation settings
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = false
+csharp_indent_labels = one_less_than_current
+
+# Spacing settings
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_declaration_parameter_list_parentheses = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = true
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = true
+csharp_space_between_parentheses = control_flow_statements, expressions
+
+# Style settings
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_prefer_braces = false:silent
+csharp_preserve_single_line_blocks = true
+csharp_using_directive_placement = outside_namespace:silent

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PilotAIAssistantControl"]
+	path = PilotAIAssistantControl
+	url = https://github.com/mitchcapper/PilotAIAssistantControl

--- a/RegExpressWPFNET/Directory.Build.props
+++ b/RegExpressWPFNET/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows7.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/RegExpressWPFNET/RegExpressLibrary/IRegexEngine.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/IRegexEngine.cs
@@ -14,8 +14,27 @@ namespace RegExpressLibrary
 
     public delegate void RegexEngineOptionsChanged( IRegexEngine sender, RegexEngineOptionsChangedArgs args );
 
+    public interface IBaseEngine
+    {
+        string Name { get; }
+        string? ExportOptions( ); // (JSON)
+    }
+    public interface IAIBase : IBaseEngine
+    {
+        string AIPatternType => "Regex";
+        string AIPatternCodeblockType => "regex";
+        string AIAdditionalSystemPrompt => "If the language supports named capture groups, use these by default. " +
+                   "If the user has ignoring patterned whitespace enabled in the options, use multi-lines and minimal in-regex comments for complex regexes with nice whitespace formatting to make it more readable. ";
 
-    public interface IRegexEngine
+        string ReferenceTextHeader => "Users current target text";
+        string GetSystemPrompt( ) => $"You are a {Name} {AIPatternType} expert assistant. The user has questions about their {AIPatternType} patterns and target text. " +
+                   $"Provide {AIPatternType} patterns inside Markdown code blocks (```{AIPatternCodeblockType} ... ```). " +
+                   "Explain how the pattern works briefly. " +
+                    AIAdditionalSystemPrompt +
+                   $"They currently have these engine options enabled:\n```json\n{ExportOptions( )}\n```";
+    }
+
+    public interface IRegexEngine : IAIBase
     {
         event RegexEngineOptionsChanged? OptionsChanged;
         event EventHandler? FeatureMatrixReady;
@@ -26,8 +45,6 @@ namespace RegExpressLibrary
 
         (string Kind, string? Version) CombinedId => (Kind, Version);
 
-        string Name { get; }
-
         string Subtitle { get; }
 
         RegexEngineCapabilityEnum Capabilities { get; }
@@ -35,8 +52,6 @@ namespace RegExpressLibrary
         string? NoteForCaptures { get; }
 
         Control GetOptionsControl( );
-
-        string? ExportOptions( ); // (JSON)
 
         void ImportOptions( string? json );
 

--- a/RegExpressWPFNET/RegExpressLibrary/InternalConfig.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/InternalConfig.cs
@@ -12,6 +12,12 @@ namespace RegExpressLibrary
     public static class InternalConfig
     {
         public static bool SHOW_DEBUG_BUTTONS = false;
+        public static bool DEBUG_LOG_AI_MESSAGES = true;
+
+        /// <summary>
+        /// as the target text can be long lets not keep the old versions around two options are update the target text with the new text, or remove the old one add a note and add the new one
+        /// </summary>
+        public static bool DONT_UPDATE_OLD_AI_TEXT_MARK_REMOVED = true;
         public static string[]? limited_engine_dlls;
         [Flags]
         public enum ON_EXCEPTION_ACTION

--- a/RegExpressWPFNET/RegExpressLibrary/InternalConfig.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/InternalConfig.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Windows;
+
+namespace RegExpressLibrary
+{
+    public static class InternalConfig
+    {
+        public static bool SHOW_DEBUG_BUTTONS = false;
+        [Flags]
+        public enum ON_EXCEPTION_ACTION
+        {
+            None,
+            MessageBox = 1 << 0,
+            DebuggerBreak = 1 << 1,
+            Rethrow = 1 << 2,
+            IncludeStackTrace = 1 << 3,
+            IncludeTraceDetails = 1 << 4,
+
+        }
+        public static ON_EXCEPTION_ACTION ON_EXCEPTION_DEBUGGER_ATTACHED = ON_EXCEPTION_ACTION.DebuggerBreak | ON_EXCEPTION_ACTION.IncludeTraceDetails | ON_EXCEPTION_ACTION.IncludeStackTrace;
+        public static ON_EXCEPTION_ACTION ON_EXCEPTION_STANDARD = ON_EXCEPTION_ACTION.MessageBox;
+        public static void HandleOtherCriticalError( String error, [System.Runtime.CompilerServices.CallerLineNumber] int source_line_number = 0, [System.Runtime.CompilerServices.CallerMemberName] string member_name = "", [System.Runtime.CompilerServices.CallerFilePath] string source_file_path = "" ) =>
+            _CriticalError( new StringBuilder( error ), source_line_number, member_name, source_file_path );
+        private static void _CriticalError( StringBuilder sb, [System.Runtime.CompilerServices.CallerLineNumber] int source_line_number = 0, [System.Runtime.CompilerServices.CallerMemberName] string member_name = "", [System.Runtime.CompilerServices.CallerFilePath] string source_file_path = "" )
+        {
+            var ON_EXCEPTION = Debugger.IsAttached ? ON_EXCEPTION_DEBUGGER_ATTACHED : ON_EXCEPTION_STANDARD;
+            if( ON_EXCEPTION.HasFlag( ON_EXCEPTION_ACTION.IncludeTraceDetails ) )
+            {
+                sb.Append( "Member: " ).AppendLine( member_name );
+                sb.Append( "File: " ).AppendLine( source_file_path );
+                sb.Append( "Line: " ).AppendLine( source_line_number.ToString( ) );
+            }
+
+            string message = sb.ToString( );
+
+            // MessageBox (on UI thread if possible)
+            if( ON_EXCEPTION.HasFlag( ON_EXCEPTION_ACTION.MessageBox ) )
+            {
+                try
+                {
+                    if( Application.Current?.Dispatcher != null && !Application.Current.Dispatcher.CheckAccess( ) )
+                        Application.Current.Dispatcher.Invoke( ( ) => MessageBox.Show( message, "Exception", MessageBoxButton.OK, MessageBoxImage.Error ) );
+                    else
+                        MessageBox.Show( message, "Exception", MessageBoxButton.OK, MessageBoxImage.Error );
+
+                }
+                catch
+                {
+                    // Fallback to Debug output if UI unavailable
+                    Debug.WriteLine( message );
+                }
+            }
+
+            // Break into debugger if requested and a debugger is attached
+            if( ON_EXCEPTION.HasFlag( ON_EXCEPTION_ACTION.DebuggerBreak ) && Debugger.IsAttached )
+                Debugger.Break( );
+
+
+            // Always log to debug output for visibility
+            Debug.WriteLine( message );
+
+        }
+
+        public static bool HandleException( String msg, Exception exception, [System.Runtime.CompilerServices.CallerLineNumber] int source_line_number = 0, [System.Runtime.CompilerServices.CallerMemberName] string member_name = "", [System.Runtime.CompilerServices.CallerFilePath] string source_file_path = "", [CallerArgumentExpression( "exception" )] string exceptionName = "" )
+        {
+            if( exception == null ) return false;
+            var ON_EXCEPTION = Debugger.IsAttached ? ON_EXCEPTION_DEBUGGER_ATTACHED : ON_EXCEPTION_STANDARD;
+
+            // Build a diagnostic message
+            StringBuilder sb = new( );
+
+            sb.AppendLine( "Exception! " );
+            if( !String.IsNullOrWhiteSpace( msg ) )
+                sb.AppendLine( msg + " " );
+            if( ON_EXCEPTION.HasFlag( ON_EXCEPTION_ACTION.IncludeTraceDetails ) )
+            {
+                sb.Append( "Member: " ).AppendLine( member_name );
+                sb.Append( "File: " ).AppendLine( source_file_path );
+                sb.Append( "Line: " ).AppendLine( source_line_number.ToString( ) );
+            }
+            sb.Append( "Exception Var: " ).AppendLine( exceptionName );
+            sb.Append( "Type: " ).AppendLine( exception.GetType( ).FullName );
+            sb.Append( "Message: " ).AppendLine( exception.Message );
+
+            if( ON_EXCEPTION.HasFlag( ON_EXCEPTION_ACTION.IncludeStackTrace ) )
+            {
+                var st = exception.StackTrace;
+                if( !string.IsNullOrWhiteSpace( st ) )
+                {
+                    sb.AppendLine( "StackTrace:" );
+                    sb.AppendLine( st );
+                }
+            }
+            _CriticalError( sb, source_line_number, member_name, source_file_path );
+
+            return ( ON_EXCEPTION.HasFlag( ON_EXCEPTION_ACTION.Rethrow ) );
+        }
+        /// <summary>
+        /// Returns true if caller should rethrow the exception
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <param name="source_line_number"></param>
+        /// <param name="member_name"></param>
+        /// <param name="source_file_path"></param>
+        /// <param name="exceptionName"></param>
+        /// <returns></returns>
+        public static bool HandleException( Exception exception, [System.Runtime.CompilerServices.CallerLineNumber] int source_line_number = 0, [System.Runtime.CompilerServices.CallerMemberName] string member_name = "", [System.Runtime.CompilerServices.CallerFilePath] string source_file_path = "", [CallerArgumentExpression( "exception" )] string exceptionName = "" ) =>
+            HandleException( string.Empty, exception, source_line_number, member_name, source_file_path, exceptionName );
+
+    }
+}

--- a/RegExpressWPFNET/RegExpressLibrary/InternalConfig.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/InternalConfig.cs
@@ -12,6 +12,7 @@ namespace RegExpressLibrary
     public static class InternalConfig
     {
         public static bool SHOW_DEBUG_BUTTONS = false;
+        public static string[]? limited_engine_dlls;
         [Flags]
         public enum ON_EXCEPTION_ACTION
         {

--- a/RegExpressWPFNET/RegExpressLibrary/PluginUtilities.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/PluginUtilities.cs
@@ -80,6 +80,11 @@ public static class PluginLoader
         {
             foreach( EngineData engine_data in engines_data.engines )
             {
+                if ( InternalConfig.limited_engine_dlls?.Length > 0 && !InternalConfig.limited_engine_dlls.Any( dll => engine_data.path.Contains(dll, StringComparison.CurrentCultureIgnoreCase) ) )
+                {
+                    Debug.WriteLine( $"Skipping plugin due to limited_engine_dlls \"{engine_data.path}\"..." );
+                    continue;
+                }
                 string plugin_absolute_path = Path.Combine( plugin_root_folder, engine_data.path! );
 
                 try

--- a/RegExpressWPFNET/RegExpressLibrary/PluginUtilities.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/PluginUtilities.cs
@@ -64,9 +64,8 @@ public static class PluginLoader
         }
         catch( Exception exc )
         {
-            if( Debugger.IsAttached ) Debugger.Break( );
-
-            MessageBox.Show( ownerWindow, $"Failed to load plugins using '{enginesJsonPath}'.\r\n\r\n{exc.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Exclamation );
+            if (InternalConfig.HandleException($"Failed to load plugins using '{enginesJsonPath}'", exc ))
+                throw;
 
             return (null, null);
         }
@@ -106,18 +105,17 @@ public static class PluginLoader
                             }
                             catch( Exception exc )
                             {
-                                if( Debugger.IsAttached ) Debugger.Break( );
+                                if (InternalConfig.HandleException( $"Failed to create plugin \"{engine_data.path}\"", exc ))
+                                    throw;
 
-                                MessageBox.Show( ownerWindow, $"Failed to create plugin \"{engine_data.path}\".\r\n\r\n{exc.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Exclamation );
                             }
                         }
                     }
                 }
                 catch( Exception exc )
                 {
-                    if( Debugger.IsAttached ) Debugger.Break( );
-
-                    MessageBox.Show( $"Failed to load plugin \"{engine_data.path}\".\r\n\r\n{exc.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Exclamation );
+                    if (InternalConfig.HandleException( $"Failed to create plugin \"{engine_data.path}\"", exc ))
+                       throw;
                 }
             }
         }

--- a/RegExpressWPFNET/RegExpressLibrary/ProcessHelper.cs
+++ b/RegExpressWPFNET/RegExpressLibrary/ProcessHelper.cs
@@ -129,7 +129,8 @@ namespace RegExpressLibrary
                     catch( Exception exc )
                     {
                         _ = exc;
-                        if( Debugger.IsAttached ) Debugger.Break( );
+                        if (InternalConfig.HandleException( exc ))
+                            throw;
                     }
                 } )
                 {
@@ -155,7 +156,8 @@ namespace RegExpressLibrary
                     catch( Exception exc )
                     {
                         _ = exc;
-                        if( Debugger.IsAttached ) Debugger.Break( );
+                        if (InternalConfig.HandleException( exc ))
+                            throw;
                     }
                 } )
                 {
@@ -174,7 +176,8 @@ namespace RegExpressLibrary
                 catch( Exception exc )
                 {
                     _ = exc;
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( exc ))
+                        throw;
                 }
             } )
             {
@@ -222,7 +225,8 @@ namespace RegExpressLibrary
                     if( unchecked((uint)exc.HResult) != 0x80004005 && // 'E_ACCESSDENIED'
                         unchecked((uint)exc.HResult) != 0x80131509 ) // -2146233079, "Cannot process request because the process (<PID>) has exited."
                     {
-                        if( Debugger.IsAttached ) Debugger.Break( );
+                        if (InternalConfig.HandleException( exc ))
+                            throw;
                     }
 
                     // ignore

--- a/RegExpressWPFNET/RegExpressLibrary/RegExpressLibrary.csproj
+++ b/RegExpressWPFNET/RegExpressLibrary/RegExpressLibrary.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
     </PropertyGroup>

--- a/RegExpressWPFNET/RegExpressLibrary/UI/CheckboxWithNote.xaml
+++ b/RegExpressWPFNET/RegExpressLibrary/UI/CheckboxWithNote.xaml
@@ -9,7 +9,7 @@
              x:Name="userControl" DataContextChanged="userControl_DataContextChanged"
              >
     <CheckBox IsChecked="{Binding IsChecked, ElementName=userControl}" HorizontalAlignment="Left">
-        <TextBlock x:Name="textBlock" HorizontalAlignment="Left" VerticalAlignment="Top" TextWrapping="Wrap">
+        <TextBlock x:Name="textBlock" HorizontalAlignment="Left" VerticalAlignment="Center" TextWrapping="Wrap">
                 <Run x:Name="run" Text="Sample text"/>
                 <Run>
                     <Run.Style>

--- a/RegExpressWPFNET/RegExpressWPFNET.slnx
+++ b/RegExpressWPFNET/RegExpressWPFNET.slnx
@@ -3,6 +3,10 @@
     <Platform Name="Any CPU" />
     <Platform Name="x64" />
   </Configurations>
+  <Folder Name="/AIAssist/">
+    <Project Path="../PilotAIAssistantControl/PilotAIAssistantControl/PilotAIAssistantControl.shproj" Id="6cd62ff6-5bd0-41d0-a512-a6587e4846da" />
+    <Project Path="../PilotAIAssistantControl/PilotAIAssistantControlWPF/PilotAIAssistantControlWPF.csproj" />
+  </Folder>
   <Folder Name="/RegexEngines/" />
   <Folder Name="/RegexEngines/Ada/">
     <Project Path="RegexEngines/Ada/AdaPlugin/AdaPlugin.csproj" />

--- a/RegExpressWPFNET/RegExpressWPFNET/Adorners/UnderliningAdorner.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Adorners/UnderliningAdorner.cs
@@ -98,7 +98,8 @@ namespace RegExpressWPFNET.Adorners
                         // TODO: 'ExecutionEngineException' is now obsolete.
 
                         _ = exc;
-                        if( Debugger.IsAttached ) Debugger.Break( );
+                        if (RegExpressLibrary.InternalConfig.HandleException( exc ))
+                            throw;
                         // ignore and accept the ranges
                     }
                 }

--- a/RegExpressWPFNET/RegExpressWPFNET/App.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/App.xaml
@@ -8,9 +8,14 @@
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              StartupUri="MainWindow.xaml"
              Startup="App_Startup"
+             ThemeMode="System"
              >
 
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
         <SolidColorBrush x:Key="NormalBackground" Color="White"/>
 
@@ -613,7 +618,7 @@
             </Setter>
         </Style>
         -->
-
+        </ResourceDictionary>
     </Application.Resources>
 
 </Application>

--- a/RegExpressWPFNET/RegExpressWPFNET/App.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/App.xaml
@@ -16,8 +16,8 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
-        <SolidColorBrush x:Key="NormalBackground" Color="White"/>
+       <local_controls:BoolNullVisibilityCollapsedConverter x:Key="boolNullVisibilityCollapsedConverter" />
+       <SolidColorBrush x:Key="NormalBackground" Color="White"/>
 
         <Style x:Key="StackPanelWithLabels" TargetType="StackPanel" PresentationOptions:Freeze="True">
             <Setter Property="Orientation" Value="Horizontal"/>
@@ -120,27 +120,34 @@
             <Setter Property="Padding" Value="1 4 0 0"/>
         </Style>
 
+            <Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+                <Setter Property="Margin" Value="3"/>
+            </Style>
+            <Style TargetType="Button" x:Key="OurAccentButtonStyle" BasedOn="{StaticResource AccentButtonStyle}">
+                <Setter Property="Margin" Value="3"/>
+            </Style>
 
-        <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
-            <Style.Triggers>
+            <Style TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}">
+                <Setter Property="MinWidth" Value="50"/>
+                <Style.Triggers>
                 <Trigger Property="IsEnabled" Value="False">
                     <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
 
-        <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
-            <Setter Property="Padding" Value="3 2"/>
-            <Setter Property="Height" Value="20"/>
-        </Style>
+            <Style TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
+                <Setter Property="Padding" Value="3 2"/>
+                <Setter Property="Margin" Value="3"/>
+            </Style>
 
-        <Style TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
+        <Style TargetType="ComboBoxItem" BasedOn="{StaticResource DefaultComboBoxItemStyle}">
             <Setter Property="Padding" Value="3 2"/>
             <Setter Property="Margin" Value="0"/>
         </Style>
 
         <Style TargetType="Separator" BasedOn="{StaticResource {x:Type Separator}}">
-            <Setter Property="Margin" Value="3 3 3 4" />
+            <Setter Property="Margin" Value="3" />
         </Style>
 
         <!-- Inline Styles -->

--- a/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
@@ -93,17 +93,20 @@ namespace RegExpressWPFNET
 
         private void TaskScheduler_UnobservedTaskException( object? sender, UnobservedTaskExceptionEventArgs e )
         {
-            if( Debugger.IsAttached ) Debugger.Break( );
+            if (RegExpressLibrary.InternalConfig.HandleException( e.Exception ))
+                    throw e.Exception;
         }
 
         private void App_DispatcherUnhandledException( object sender, DispatcherUnhandledExceptionEventArgs e )
         {
-            if( Debugger.IsAttached ) Debugger.Break( );
+            if (RegExpressLibrary.InternalConfig.HandleException( e.Exception ))
+                    throw e.Exception;
         }
 
         private void Dispatcher_UnhandledException( object sender, DispatcherUnhandledExceptionEventArgs e )
         {
-            if( Debugger.IsAttached ) Debugger.Break( );
+            if (RegExpressLibrary.InternalConfig.HandleException( e.Exception ))
+                    throw e.Exception;
         }
     }
 }

--- a/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RegExpressWPFNET.Code;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
@@ -60,6 +61,11 @@ namespace RegExpressWPFNET
                 Shutdown( );
 
                 return;
+            }
+            var onlyEngine = Utilities.GetCommandLineArgStr( "only-engine-dll" );
+            if( !String.IsNullOrWhiteSpace( onlyEngine ) )
+            {
+                RegExpressLibrary.InternalConfig.limited_engine_dlls = new[] { onlyEngine! };
             }
         }
 

--- a/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
@@ -49,7 +49,7 @@ namespace RegExpressWPFNET
 
                 SetForegroundWindow( other_process.MainWindowHandle );
 
-                Shutdown( );
+                Environment.Exit(0); // Calling shutdown still constructs MainWindow.xaml which in turn attempts to save the session before it loads erasing the session data
 
                 return;
             }
@@ -58,7 +58,7 @@ namespace RegExpressWPFNET
 
             if( other_process != null )
             {
-                Shutdown( );
+                Environment.Exit(0); // Calling shutdown still constructs MainWindow.xaml which in turn attempts to save the session before it loads erasing the session data
 
                 return;
             }

--- a/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/App.xaml.cs
@@ -62,10 +62,10 @@ namespace RegExpressWPFNET
 
                 return;
             }
-            var onlyEngine = Utilities.GetCommandLineArgStr( "only-engine-dll" );
-            if( !String.IsNullOrWhiteSpace( onlyEngine ) )
+            var onlyEngine = Utilities.GetCommandLineArgArr( "only-engine-dll" );
+            if( onlyEngine.Length > 0 )
             {
-                RegExpressLibrary.InternalConfig.limited_engine_dlls = new[] { onlyEngine! };
+                RegExpressLibrary.InternalConfig.limited_engine_dlls = onlyEngine;
             }
         }
 

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/ChangeEventHelper.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/ChangeEventHelper.cs
@@ -82,7 +82,7 @@ namespace RegExpressWPFNET.Code
                 catch( Exception exc )
                 {
                     _ = exc;
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    RegExpressLibrary.InternalConfig.HandleException( exc );
                     throw;
                 }
             }
@@ -106,7 +106,7 @@ namespace RegExpressWPFNET.Code
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                RegExpressLibrary.InternalConfig.HandleException( exc );
                 throw;
             }
             finally

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/OutputBuilder.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/OutputBuilder.cs
@@ -63,12 +63,13 @@ namespace RegExpressWPFNET.Code
             sb.Clear( );
             runs.Clear( );
             isPreviousSpecial = false;
+            int realLength = 0;
 
             for( int i = 0; i < text.Length; i++ )
             {
-                if( i >= maxLength )
+                if( realLength >= maxLength )
                 {
-                    AppendSpecial( @"…" );
+                    realLength += AppendSpecial( @"…" );
 
                     break;
                 }
@@ -78,13 +79,13 @@ namespace RegExpressWPFNET.Code
                 switch( c )
                 {
                 case '\r':
-                    AppendSpecial( @"\r" );
+                    realLength += AppendSpecial( @"\r" );
                     continue;
                 case '\n':
-                    AppendSpecial( @"\n" );
+                    realLength += AppendSpecial( @"\n" );
                     continue;
                 case '\t':
-                    AppendSpecial( @"\t" );
+                    realLength += AppendSpecial( @"\t" );
                     continue;
                 }
 
@@ -100,7 +101,7 @@ namespace RegExpressWPFNET.Code
                     ( c >= UnicodeRanges.Hebrew.FirstCodePoint && c < UnicodeRanges.Hebrew.FirstCodePoint + UnicodeRanges.Hebrew.Length && char.GetUnicodeCategory( c ) == UnicodeCategory.OtherLetter )
                   )
                 {
-                    AppendNormal( c );
+                    realLength += AppendNormal( c );
                     continue;
                 }
 
@@ -138,13 +139,13 @@ namespace RegExpressWPFNET.Code
                 case UnicodeCategory.OtherSymbol:
                 //case UnicodeCategory.OtherNotAssigned:
                       */
-                    AppendNormal( c );
+                    realLength += AppendNormal( c );
 
                     break;
 
                 default:
 
-                    AppendCode( c );
+                    realLength += AppendCode( c );
 
                     break;
                 }
@@ -209,7 +210,7 @@ namespace RegExpressWPFNET.Code
         }
 
 
-        private void AppendSpecial( string s )
+        private int AppendSpecial( string s )
         {
             if( isPreviousSpecial || specialStyleInfo == null )
             {
@@ -226,16 +227,17 @@ namespace RegExpressWPFNET.Code
                 sb.Clear( ).Append( s );
                 isPreviousSpecial = true;
             }
+            return s.Length;
         }
 
 
-        private void AppendCode( char c )
+        private int AppendCode( char c )
         {
-            AppendSpecial( $@"\u{(int)c:X4}" );
+            return AppendSpecial( $@"\u{(int)c:X4}" );
         }
 
 
-        private void AppendNormal( char c )
+        private int AppendNormal( char c )
         {
             if( !isPreviousSpecial )
             {
@@ -252,6 +254,7 @@ namespace RegExpressWPFNET.Code
                 sb.Clear( ).Append( c );
                 isPreviousSpecial = false;
             }
+            return 1;
         }
     }
 }

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/ResumableLoop.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/ResumableLoop.cs
@@ -220,7 +220,7 @@ namespace RegExpressWPFNET.Code
                     catch( Exception exc )
                     {
                         _ = exc;
-                        if( Debugger.IsAttached ) Debugger.Break( );
+                        InternalConfig.HandleException( exc );
 
                         throw; // TODO: maybe restart the loop?
                     }
@@ -237,7 +237,7 @@ namespace RegExpressWPFNET.Code
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                InternalConfig.HandleException(exc);
                 throw;
             }
         }

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/RtbUtilities.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/RtbUtilities.cs
@@ -477,7 +477,7 @@ namespace RegExpressWPFNET.Code
 
             if( rect_to_bring.IsEmpty )
             {
-                if( Debugger.IsAttached ) Debugger.Break( );
+                InternalConfig.HandleOtherCriticalError("Rect is empty");
 
                 return;
             }
@@ -490,7 +490,7 @@ namespace RegExpressWPFNET.Code
         {
             if( rect.IsEmpty )
             {
-                if( Debugger.IsAttached ) Debugger.Break( );
+                InternalConfig.HandleOtherCriticalError("Rect is empty");
 
                 return;
             }

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/TabData.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/TabData.cs
@@ -38,6 +38,8 @@ namespace RegExpressWPFNET.Code
     class AllTabData
     {
         public List<TabData> Tabs { get; set; } = new( );
+        public PilotAIAssistantControl.AIUserConfig AIConfig { get; set; } = new( );
+        public bool AITabOpen { get; set; } = false;
     }
 
 

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/UITaskHelper.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/UITaskHelper.cs
@@ -47,7 +47,7 @@ namespace RegExpressWPFNET.Code
 			catch( Exception exc )
 			{
 				_ = exc;
-				if( Debugger.IsAttached ) Debugger.Break( );
+				RegExpressLibrary.InternalConfig.HandleException( exc );
 				throw;
 			}
 		}
@@ -66,7 +66,8 @@ namespace RegExpressWPFNET.Code
 			catch( Exception exc )
 			{
 				_ = exc;
-				if( Debugger.IsAttached && !( exc is TaskCanceledException ) ) Debugger.Break( );
+				if(!( exc is TaskCanceledException ) )
+                    RegExpressLibrary.InternalConfig.HandleException( exc );
 				throw;
 			}
 		}
@@ -118,7 +119,7 @@ namespace RegExpressWPFNET.Code
 			catch( Exception exc )
 			{
 				_ = exc;
-				if( Debugger.IsAttached ) Debugger.Break( );
+				RegExpressLibrary.InternalConfig.HandleException( exc );
 				throw;
 			}
 		}

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/Utilities.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/Utilities.cs
@@ -47,6 +47,26 @@ namespace RegExpressWPFNET.Code
             return PixelsFromInvariantString( value ) * r;
         }
 
+        private static string[]? _commandLineArgs;
+        public static bool GetCommandLineArg( String arg, out String? NextVal )
+        {
+            _commandLineArgs ??= Environment.GetCommandLineArgs( );
+            var pos = Array.IndexOf( _commandLineArgs, "--" + arg );
+            NextVal = null;
+            if( pos == -1 )
+                return false;
+            if( pos + 1 < _commandLineArgs.Length )
+                NextVal = _commandLineArgs[pos + 1];
+            return true;
+        }
+        public static string? GetCommandLineArgStr( String arg )
+        {
+            if (! GetCommandLineArg( arg, out String? NextVal ))
+                return null;
+            return NextVal;
+        }
+        public static bool GetCommandLineExists(String arg) => GetCommandLineArg( arg, out _ );
+
 
         [Conditional( "DEBUG" )]
         public static void DbgSimpleLog( Exception exc, [CallerFilePath] string? filePath = null, [CallerMemberName] string? memberName = null, [CallerLineNumber] int lineNumber = 0 )

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/Utilities.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/Utilities.cs
@@ -48,16 +48,42 @@ namespace RegExpressWPFNET.Code
         }
 
         private static string[]? _commandLineArgs;
-        public static bool GetCommandLineArg( String arg, out String? NextVal )
+        public static bool GetCommandLineArg( String arg, out String? NextVal ) {
+            NextVal=null;
+            var arr = GetCommandLineArgArr( arg, 1 );
+            if (arr.Length == 0)
+                return false;
+            NextVal = arr[0];
+            return true;
+        }
+        /// <summary>
+        /// return an array with each occurrence of the arg, allows --ignore a --ignore b
+        /// </summary>
+        /// <param name="arg"></param>
+        /// <returns></returns>
+        public static string[] GetCommandLineArgArr( string arg, int max = 0 )
         {
             _commandLineArgs ??= Environment.GetCommandLineArgs( );
-            var pos = Array.IndexOf( _commandLineArgs, "--" + arg );
-            NextVal = null;
-            if( pos == -1 )
-                return false;
-            if( pos + 1 < _commandLineArgs.Length )
-                NextVal = _commandLineArgs[pos + 1];
-            return true;
+            List<string> ret = new();
+            bool addNext = false;
+            string targetArg = "--" + arg;
+
+            foreach( var cmdArg in _commandLineArgs )
+            {
+                if( cmdArg.Equals( targetArg, StringComparison.CurrentCultureIgnoreCase) )
+                {
+                    addNext = true;
+                }
+                else if( addNext )
+                {
+                    ret.Add( cmdArg );
+                    if (ret.Count == max)
+                        break;
+                    addNext = false;
+                }
+            }
+
+            return ret.ToArray( );
         }
         public static string? GetCommandLineArgStr( String arg )
         {

--- a/RegExpressWPFNET/RegExpressWPFNET/Code/Utilities.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Code/Utilities.cs
@@ -69,7 +69,8 @@ namespace RegExpressWPFNET.Code
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (RegExpressLibrary.InternalConfig.HandleException( exc ))
+                    throw;
             }
         }
 
@@ -88,7 +89,8 @@ namespace RegExpressWPFNET.Code
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (RegExpressLibrary.InternalConfig.HandleException( exc ))
+                    throw;
             }
         }
     }

--- a/RegExpressWPFNET/RegExpressWPFNET/Controls/BaseBoolNullConverter.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/Controls/BaseBoolNullConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace RegExpressWPFNET.Controls
+{
+
+    public class BoolNullVisibilityCollapsedConverter( ) : BaseBoolNullConverter( Visibility.Visible, Visibility.Collapsed ), IValueConverter
+    {
+    }
+    public abstract class BaseBoolNullConverter( object true_val, object false_val )
+    {
+
+        public object Convert( object value, Type targetType, object parameter, CultureInfo? culture )
+        {
+            var res = GetConvertResult( value, parameter );
+            if( targetType == typeof( Boolean ) )
+                return res;
+            return res ? true_val : false_val;
+        }
+        //uwp
+        public object Convert( object value, Type targetType, object parameter, string language ) => Convert( value, targetType, parameter, default( CultureInfo ) );
+        public static bool GetConvertResult( object value, object parameter )
+        {
+            bool res = true;
+            if( value == null )
+                res = false;
+            else if( value is string sv )
+                res = !String.IsNullOrWhiteSpace( sv );
+            else if( value is bool bv )
+                res = bv;
+            if( parameter != null && ( ( parameter.GetType( ) == typeof( bool ) && ( (bool)parameter ) ) || ( parameter.GetType( ) == typeof( string ) && new string[] { "true", "1" }.Contains( parameter as string ) ) ) )
+                res = !res;
+            return res;
+        }
+        public object ConvertBack( object value, Type targetType, object parameter, CultureInfo culture ) => throw new NotImplementedException( );
+        public object ConvertBack( object value, Type targetType, object parameter, string language ) => throw new NotImplementedException( );
+    }
+}

--- a/RegExpressWPFNET/RegExpressWPFNET/MainWindow.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/MainWindow.xaml
@@ -3,6 +3,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:pia="clr-namespace:PilotAIAssistantControl;assembly=PilotAIAssistantControlWPF"
+
         xmlns:local="clr-namespace:RegExpressWPFNET"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
@@ -33,8 +35,27 @@
         <KeyBinding Command="{x:Static local:MainWindow.MoveTabLeftCommand}" Modifiers="Ctrl+Shift+Alt" Key="Left" />
         <KeyBinding Command="{x:Static local:MainWindow.MoveTabRightCommand}" Modifiers="Ctrl+Shift+Alt" Key="Right" />
     </Window.InputBindings>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="AiColumn" MinWidth="40" Width="Auto"/>
+            <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
 
-    <Grid Margin="0 1 0 0">
+        <pia:UCAIExpandable x:Name="ucAi" Foreground="{x:Static SystemColors.AccentColorBrush}"
+                        TargetColumn="{Binding ElementName=AiColumn}"
+                        DefaultSize="400"
+                        MinExpandedSize="200"
+                        CollapsedSize="40"/>
+
+        <!-- AI Expander (just the header/toggle) -->
+
+
+        <!-- Resizable Splitter (visible when expanded) -->
+        <GridSplitter x:Name="aiSplitter" Grid.Column="1" Visibility="{Binding IsExpanded, Mode=OneWay, ElementName=aiExpander, Converter={StaticResource boolNullVisibilityCollapsedConverter}}" IsTabStop="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="#E0E0E0" ResizeBehavior="PreviousAndNext" />
+
+        <!-- Main Content -->
+        <Grid Margin="0 1 0 0" Grid.Column="2">
 
         <TextBlock x:Name="textBlockInfo" Text="Loading..." TextAlignment="Center" VerticalAlignment="Center" Panel.ZIndex="2"/>
 
@@ -187,5 +208,5 @@
             </TabItem>
         </TabControl>
     </Grid>
-
+    </Grid>
 </Window>

--- a/RegExpressWPFNET/RegExpressWPFNET/MainWindow.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/MainWindow.xaml.cs
@@ -130,7 +130,8 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (RegExpressLibrary.InternalConfig.HandleException( exc ))
+                    throw;
             }
 
 #if DEBUG
@@ -224,7 +225,7 @@ namespace RegExpressWPFNET
                 }
                 catch( Exception exc )
                 {
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if( Debugger.IsAttached ) InternalConfig.HandleException( exc );
                     else Debug.Fail( exc.Message, exc.ToString( ) );
 
                     // ignore
@@ -465,7 +466,8 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 // ignore
             }
@@ -518,7 +520,7 @@ namespace RegExpressWPFNET
             }
             catch( Exception exc )
             {
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if( Debugger.IsAttached ) InternalConfig.HandleException( exc );
                 else Debug.Fail( exc.Message, exc.ToString( ) );
 
                 // ignore
@@ -588,7 +590,7 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if( Debugger.IsAttached ) InternalConfig.HandleException( exc );
 
                 // ignore
             }

--- a/RegExpressWPFNET/RegExpressWPFNET/MainWindow.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/MainWindow.xaml.cs
@@ -27,6 +27,8 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using System.Xml;
+
+using PilotAIAssistantControl;
 using RegExpressLibrary;
 using RegExpressWPFNET.Code;
 using Path = System.IO.Path;
@@ -130,7 +132,7 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if (RegExpressLibrary.InternalConfig.HandleException( exc ))
+                if( RegExpressLibrary.InternalConfig.HandleException( exc ) )
                     throw;
             }
 
@@ -177,6 +179,13 @@ namespace RegExpressWPFNET
                 {
                     taskBarItemInfo.ProgressState = System.Windows.Shell.TaskbarItemProgressState.None;
                 }
+
+                // Import AI settings
+                //all_tab_data.AIConfig = new();
+                ucAi.ImportData( all_tab_data.AIConfig );
+                if( all_tab_data.AITabOpen )
+                    ucAi.IsExpanded = true;
+
             }
 
             // --- Delay effect
@@ -210,7 +219,14 @@ namespace RegExpressWPFNET
                 var old_metrics = old_uc_main.GetMetrics( );
                 new_uc_main.ApplyMetrics( old_metrics, full: false );
             }
+            if( new_uc_main != null )
+            {
+                AiOptions.CurrentTab = new_uc_main;
+                ucAi.Configure( AiOptions );
+            }
+
         }
+        OurIAIUIOptions AiOptions = new( );
 
 
         private void Window_Closing( object sender, System.ComponentModel.CancelEventArgs e )
@@ -429,6 +445,10 @@ namespace RegExpressWPFNET
                     all_data.Tabs.Add( tab_data );
                 }
 
+
+                all_data.AIConfig =  ucAi.ExportData( );
+                all_data.AITabOpen = ucAi.IsExpanded;
+
                 string json = JsonSerializer.Serialize( all_data, PluginLoader.JsonOptions );
                 string my_file = GetMyDataFile( );
 
@@ -466,7 +486,7 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if (InternalConfig.HandleException( exc ))
+                if( InternalConfig.HandleException( exc ) )
                     throw;
 
                 // ignore
@@ -776,10 +796,54 @@ namespace RegExpressWPFNET
         }
 
 
+        private void AiExpander_Expanded( object sender, RoutedEventArgs e )
+        {
+            // Connect the AI panel to the current tab when expanded
+            var uc_main = GetActiveUCMain( );
+            if( uc_main != null )
+            {
+                AiOptions.CurrentTab = uc_main;
+                ucAi.Configure( AiOptions );
+            }
+        }
+
+
         [GeneratedRegex( @"^Regex\s*(\d+)$" )]
         private static partial Regex HeaderParserRegex( );
 
         #endregion
 
+
+
+        public class OurIAIUIOptions : AIOptions
+        {
+            public override string HintForUserInput => "Ask about a regex or matching...";
+            public override string ReferenceTextDisplayName => "Target Text";
+            public override string FormatUserQuestion( string userQuestion ) => $"Current pattern:\n```{CurrentTab.CurrentRegexEngine?.AIPatternCodeblockType}\n{CurrentTab.ucPattern.GetTextData( "\n" ).Text}\n```\n\nMy question: {userQuestion}";
+            public UCMain? CurrentTab;
+
+            public override string GetCurrentReferenceText( ) => CurrentTab?.ucText.GetTextData( "\n" ).Text;
+            public override IEnumerable<ICodeblockAction> CodeblockActions => [ GenericCodeblockAction.ClipboardAction,
+                new GenericCodeblockAction("📝 Use as Pattern", async ( block ) =>
+                {
+
+                    if( CurrentTab == null ) return false;
+                    CurrentTab.ucPattern.SetText( block.Code );
+                    return true;
+                } )
+                {
+                    Tooltip="Use this code block as the regex pattern",
+                    FeedbackOnAction="✓ Applied!"
+                }
+        ];
+
+            public override void HandleDebugMessage( string msg )
+            {
+                if( InternalConfig.DEBUG_LOG_AI_MESSAGES )
+                    System.Diagnostics.Debug.WriteLine( msg );
+            }
+
+            public override string GetSystemPrompt( ) => CurrentTab?.CurrentRegexEngine?.GetSystemPrompt( ) ?? null;
+        }
     }
 }

--- a/RegExpressWPFNET/RegExpressWPFNET/RegExpressWPFNET.csproj
+++ b/RegExpressWPFNET/RegExpressWPFNET/RegExpressWPFNET.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <ApplicationIcon>RegExpress.ico</ApplicationIcon>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
 
     <ItemGroup>

--- a/RegExpressWPFNET/RegExpressWPFNET/RegExpressWPFNET.csproj
+++ b/RegExpressWPFNET/RegExpressWPFNET/RegExpressWPFNET.csproj
@@ -4,6 +4,7 @@
         <OutputType>WinExe</OutputType>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
+        <LangVersion>preview</LangVersion>
         <ApplicationIcon>RegExpress.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
@@ -19,6 +20,12 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="MdXaml" Version="1.27.0" />
+      <PackageReference Include="Microsoft.SemanticKernel" Version="1.67.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\PilotAIAssistantControl\PilotAIAssistantControlWPF\PilotAIAssistantControlWPF.csproj" />
         <ProjectReference Include="..\RegExpressLibrary\RegExpressLibrary.csproj" />
     </ItemGroup>
 

--- a/RegExpressWPFNET/RegExpressWPFNET/RegExpressWPFNET.csproj
+++ b/RegExpressWPFNET/RegExpressWPFNET/RegExpressWPFNET.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <ApplicationIcon>RegExpress.ico</ApplicationIcon>

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml
@@ -235,7 +235,7 @@
                                         </TransformGroup>
                                     </StackPanel.LayoutTransform>
                                     <Label Content="Newline:" VerticalAlignment="Center" Target="{Binding ElementName=cbxEol}"/>
-                                    <ComboBox x:Name="cbxEol" VerticalAlignment="Center" Margin="3 0 0 0" SelectionChanged="CbxEol_SelectionChanged" >
+                                    <ComboBox x:Name="cbxEol" VerticalAlignment="Center" Margin="3 0 0 0" SelectionChanged="CbxEol_SelectionChanged" Width="220" >
                                         <ComboBox.Resources>
                                             <Style x:Key="Note" TargetType="TextBlock">
                                                 <Setter Property="Opacity" Value="0.77"/>

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml
@@ -5,11 +5,11 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:RegExpressWPFNET"
         mc:Ignorable="d"
-        Width="800" 
-        Height="450" 
-        Loaded="UserControl_Loaded" 
+        Width="800"
+        Height="450"
+        Loaded="UserControl_Loaded"
         Unloaded="UserControl_Unloaded"
-        IsVisibleChanged="UserControl_IsVisibleChanged" 
+        IsVisibleChanged="UserControl_IsVisibleChanged"
         >
 
 	<Grid Margin="9 7 9 9">
@@ -116,7 +116,7 @@
                     </StackPanel>
                 </Grid>
                 <Border Grid.Row="1" Margin="0" Style="{StaticResource RtbBorder}" >
-                    <local:UCMatches x:Name="ucMatches" SelectionChanged="UcMatches_SelectionChanged" Cancelled="UcMatches_Cancelled" LostFocus="UcMatches_LostFocus" Margin="0 -0.05 0 0">
+                    <local:UCMatches x:Name="ucMatches" SelectionChanged="UcMatches_SelectionChanged" Cancelled="UcMatches_Cancelled" ScopeToMatchRequested="UcMatches_ScopeToMatchRequested" LostFocus="UcMatches_LostFocus" Margin="0 -0.05 0 0">
                         <local:UCMatches.Clip>
                             <MultiBinding Converter="{StaticResource BorderClipConverter}">
                                 <Binding Path="ActualWidth"  RelativeSource="{RelativeSource Self}"/>
@@ -182,7 +182,7 @@
                                                     <ColumnDefinition />
                                                 </Grid.ColumnDefinitions>
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="1 0 0 0"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding Version, TargetNullValue='Unknown version', FallbackValue='Unknown version'}" VerticalAlignment="Center" HorizontalAlignment="Left" 
+                                                <TextBlock Grid.Column="1" Text="{Binding Version, TargetNullValue='Unknown version', FallbackValue='Unknown version'}" VerticalAlignment="Center" HorizontalAlignment="Left"
                                                            Margin="6 0 1 0">
                                                     <!--<TextBlock.LayoutTransform>
                                                         <ScaleTransform ScaleX="0.8" ScaleY="1"/>
@@ -218,7 +218,7 @@
                                 <CheckBox x:Name="cbUnderline" Content="Underline current match" Checked="CbUnderline_CheckedChanged" Unchecked="CbUnderline_CheckedChanged" HorizontalAlignment="Left"/>
                                 <CheckBox x:Name="cbShowWhitespaces" Checked="CbShowWhitespaces_CheckedChanged" Unchecked="CbShowWhitespaces_CheckedChanged" HorizontalAlignment="Left">
                                     <TextBlock>
-                                            Show whitespaces 
+                                            Show whitespaces
                                             <Span x:Name="lblWarnings">
                                                 <Run x:Name="lblWhitespaceWarning1" Foreground="OrangeRed" ToolTip="There are imperceptible whitespaces. Click to show.">&#x26a0;</Run>
                                                 <Run x:Name="lblWhitespaceWarning2" Foreground="Silver" ToolTip="There are imperceptible whitespaces.">&#x26a0;</Run>

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml
@@ -12,8 +12,16 @@
         IsVisibleChanged="UserControl_IsVisibleChanged" 
         >
 
-    <Grid Margin="9 7 9 9">
-        <Grid.ColumnDefinitions>
+	<Grid Margin="9 7 9 9">
+		<Grid.Resources>
+			<Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+				<Setter Property="Margin" Value="5,0" />
+                <Setter Property="FontSize" Value="11" />
+                <Setter Property="Padding" Value="2" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+			</Style>
+		</Grid.Resources>
+		<Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" MinWidth="33"/>
             <ColumnDefinition Width="5"/>
             <ColumnDefinition x:Name="RightColumn" Width="222" MinWidth="33"/>
@@ -67,7 +75,8 @@
 
                     <StackPanel Style="{StaticResource StackPanelWithLabels}" HorizontalAlignment="Left" >
                         <TextBlock Text="Text" Style="{StaticResource Labels}" />
-                    </StackPanel>
+                        <Button Content="Load File" Click="LoadFile_Click" />
+					</StackPanel>
                     <TextBlock x:Name="lblTextInfo" d:Text="Index: 10  |  Length: 200" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0 0 9 1"
                                FontSize="9.25" Opacity="0.77"/>
                 </Grid>

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml.cs
@@ -257,6 +257,16 @@ namespace RegExpressWPFNET
                     StopAll( );
                     RestartAll( );
                 }
+                var loadFile = Utilities.GetCommandLineArgStr( "text-load-file" );
+                if( !String.IsNullOrWhiteSpace( loadFile ) )
+                {
+                    ucText.SetText( File.ReadAllText( loadFile ) );
+                }
+                loadFile = Utilities.GetCommandLineArgStr( "pattern-load-file" );
+                if( !String.IsNullOrWhiteSpace( loadFile ) )
+                {
+                    ucPattern.SetText( File.ReadAllText( loadFile ) );
+                }
             }
         }
 
@@ -1154,5 +1164,26 @@ namespace RegExpressWPFNET
         [GeneratedRegex( @"\t|([ ](\r|\n|$))|((\r|\n)$)", RegexOptions.ExplicitCapture )]
         private static partial Regex HasWhitespaceRegex( );
 
+        private void LoadFile_Click( object sender, RoutedEventArgs e )
+        {
+            var openFileDialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = "All files (*.*)|*.*|Text files (*.txt)|*.txt",
+                FilterIndex = 1
+            };
+
+            if( openFileDialog.ShowDialog( ) == true )
+            {
+                try
+                {
+                    string fileContent = File.ReadAllText( openFileDialog.FileName );
+                    ucText.SetText( fileContent );
+                }
+                catch( Exception ex )
+                {
+                    MessageBox.Show( $"Error reading file: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error );
+                }
+            }
+        }
     }
 }

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml.cs
@@ -879,7 +879,7 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if( Debugger.IsAttached ) InternalConfig.HandleException( exc );
 
                 // ignore
             }
@@ -899,7 +899,7 @@ namespace RegExpressWPFNET
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                InternalConfig.HandleException( exc );
 
                 // ignore
             }

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMain.xaml.cs
@@ -35,7 +35,7 @@ namespace RegExpressWPFNET
 
         readonly IReadOnlyList<IRegexEngine> RegexEngines;
         readonly IRegexEngine DefaultRegexEngine;
-        IRegexEngine? CurrentRegexEngine = null;
+        public IRegexEngine? CurrentRegexEngine = null;
         readonly HashSet<IRegexEngine> RegexEnginesUsed = new( );
 
         public bool IsFullyLoaded { get; private set; } = false;

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMatches.xaml
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMatches.xaml
@@ -1,23 +1,24 @@
 ﻿<UserControl x:Class="RegExpressWPFNET.UCMatches"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:RegExpressWPFNET"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="200" d:DesignWidth="500" Loaded="UserControl_Loaded">
     <Grid>
         <ProgressBar x:Name="pbProgress" Panel.ZIndex="2" VerticalAlignment="Top" Visibility="Hidden" Style="{StaticResource ProgressBar1}" />
         <ProgressBar x:Name="pbProgressIndeterminate" Panel.ZIndex="10" VerticalAlignment="Top" Visibility="Hidden" Style="{StaticResource ProgressBar1}" IsIndeterminate="True" />
 
         <AdornerDecorator>
-            <RichTextBox x:Name="rtbMatches" Panel.ZIndex="1" Style="{StaticResource Matches}" 
-                         SelectionChanged="RtbMatches_SelectionChanged" 
-                         GotFocus="RtbMatches_GotFocus" 
-                         LostFocus="RtbMatches_LostFocus" 
-                         IsUndoEnabled="False" 
-                         IsReadOnly="True" 
-                         IsReadOnlyCaretVisible="True" 
+            <RichTextBox x:Name="rtbMatches" Panel.ZIndex="1" Style="{StaticResource Matches}"
+                         SelectionChanged="RtbMatches_SelectionChanged"
+                         GotFocus="RtbMatches_GotFocus"
+                         LostFocus="RtbMatches_LostFocus"
+                         IsUndoEnabled="False"
+                         IsReadOnly="True"
+                         IsReadOnlyCaretVisible="True"
+                         IsDocumentEnabled="True"
                          Visibility="Hidden"
                          d:Visibility="Visible" >
                 <FlowDocument>
@@ -37,8 +38,8 @@
             </RichTextBox>
         </AdornerDecorator>
 
-        <RichTextBox x:Name="rtbNoMatches" Style="{StaticResource Info}" IsReadOnly="True" IsReadOnlyCaretVisible="True" 
-                     Visibility="Hidden" 
+        <RichTextBox x:Name="rtbNoMatches" Style="{StaticResource Info}" IsReadOnly="True" IsReadOnlyCaretVisible="True"
+                     Visibility="Hidden"
                      d:Visibility="Hidden">
             <FlowDocument>
                 <Paragraph Padding="1 4 1 1">
@@ -55,7 +56,7 @@
             </FlowDocument>
         </RichTextBox>
 
-        <RichTextBox x:Name="rtbInfo" Panel.ZIndex="8" Style="{StaticResource Info}" IsReadOnly="True" IsReadOnlyCaretVisible="True" 
+        <RichTextBox x:Name="rtbInfo" Panel.ZIndex="8" Style="{StaticResource Info}" IsReadOnly="True" IsReadOnlyCaretVisible="True"
                      IsDocumentEnabled="True"
                      Visibility="Hidden"
                      d:Visibility="Hidden"
@@ -70,7 +71,7 @@
             </FlowDocument>
         </RichTextBox>
 
-        <RichTextBox x:Name="rtbError" Style="{StaticResource Error}" IsReadOnly="True" IsReadOnlyCaretVisible="True" 
+        <RichTextBox x:Name="rtbError" Style="{StaticResource Error}" IsReadOnly="True" IsReadOnlyCaretVisible="True"
                      Visibility="Hidden"
                      d:Visibility="Hidden">
             <FlowDocument>
@@ -86,8 +87,8 @@
             <Button x:Name="btnDbgLoad" Content="load" Click="BtnDbgLoad_Click" />
         </StackPanel>
 
-        <Grid x:Name="pnlHourglass" Panel.ZIndex="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0 0 0 1" Opacity="0.44" 
-              Visibility="Hidden" 
+        <Grid x:Name="pnlHourglass" Panel.ZIndex="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0 0 0 1" Opacity="0.44"
+              Visibility="Hidden"
               d:Visibility="Visible">
             <TextBlock Text="⏳"/>
         </Grid>

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMatches.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMatches.xaml.cs
@@ -367,6 +367,8 @@ namespace RegExpressWPFNET
             adorner_layer.Add( LocalUnderliningAdorner );
             adorner_layer.Add( ExternalUnderliningAdorner );
 
+            rtbMatches.SizeChanged += RtbMatches_SizeChanged;
+
             AlreadyLoaded = true;
         }
 
@@ -414,9 +416,28 @@ namespace RegExpressWPFNET
         }
 
 
+        private void RtbMatches_SizeChanged( object sender, SizeChangedEventArgs e )
+        {
+            if( e.WidthChanged )
+            {
+                ShowMatchesLoop.SignalRewind( );
+                ShowMatchesLoop.SignalWaitAndExecute( );
+            }
+        }
+
+        /* These two directly relate to each other.  the larger the multiplier the more negative the padding consideration.  The idea is to try and make sure lines dont overflow when super small or when very long.
+
+
+        */
+        static double CharWidthMultiplier = 1.00;
+        static int viewportPaddingConsideration = 20;
+        static int MaxPaddedSuffix = 21; // "(index, length)" suffix  14 is 6 digits for index and 4 for length, this only effects our wrap calculations but the bigger it is the more space at end of line
+        string GetMatchIndexAndLengthSuffix(int index1, int len1) => ($"\x200E  （{index1}, {len1}）").PadLeft(MaxPaddedSuffix);
         void ShowMatchesThreadProc( ICancellable cnc )
         {
             int match_infos_version = 0;
+            viewportPaddingConsideration = 5;
+            CharWidthMultiplier = 1.03;
 
             lock( MatchInfos )
             {
@@ -463,6 +484,8 @@ namespace RegExpressWPFNET
             Typeface? type_face = null;
             double font_size = 0;
             double pixels_per_dip = 0;
+            double viewport_width = 0;
+            double char_width = 10; //number doesn't really matter we will compute it
 
             ChangeEventHelper.Invoke( CancellationToken.None, ( ) =>
             {
@@ -496,6 +519,10 @@ namespace RegExpressWPFNET
                 type_face = new Typeface( rtbMatches.FontFamily, rtbMatches.FontStyle, rtbMatches.FontWeight, rtbMatches.FontStretch );
                 font_size = rtbMatches.FontSize;
                 pixels_per_dip = VisualTreeHelper.GetDpi( rtbMatches ).PixelsPerDip;
+
+                viewport_width = rtbMatches.ViewportWidth;
+                var formatted_text = new FormattedText( "W", CultureInfo.CurrentCulture, FlowDirection.LeftToRight, type_face, font_size, Brushes.Black, pixels_per_dip );
+                char_width = formatted_text.Width * CharWidthMultiplier;
             } );
 
             if( cnc.IsCancellationRequested ) return;
@@ -508,6 +535,15 @@ namespace RegExpressWPFNET
             double max_text_width = 0;
 
             int left_width = EvaluateLeftWidth( matches, show_succeeded_groups_only );
+
+            // Calculate max content chars once - all rows share the same left column width
+            int max_content_chars = 10; // minimum
+            {
+                double left_col_width = left_width * char_width;
+                double suffix_width = MaxPaddedSuffix * char_width; 
+                double available = viewport_width - left_col_width - suffix_width - viewportPaddingConsideration;
+                max_content_chars = Math.Max( max_content_chars, (int)( available / char_width ) );
+            }
 
             foreach( IMatch match in matches.Matches )
             {
@@ -597,12 +633,17 @@ namespace RegExpressWPFNET
                         }
                         else
                         {
-                            (value_inline, string value_plain_text) = match_run_builder.Build( match.Value, span.ContentEnd, MaxMatchLength + right_space_for_match );
-                            value_inline.Style( MatchValueStyleInfo, highlight_style );
-                            plain_text += value_plain_text;
+                            // Use TruncateAndRender for consistency with Groups/Captures
+                            // Match has no left/right context, so pass empty strings
+                            OutputBuilder sibling_builder = new( null ); // not used but required by signature
+                            value_inline = TruncateAndRender( span,
+                                "", match.Value, "",  // no left/right context
+                                max_content_chars,
+                                match_run_builder, sibling_builder,
+                                MatchValueStyleInfo, highlight_style, GroupSiblingValueStyleInfo );
                         }
 
-                        string index_and_length = $"\x200E  （{match.Index}, {match.Length}）";
+                        string index_and_length = GetMatchIndexAndLengthSuffix(match.Index,match.Length);
                         run = new Run( index_and_length, span.ContentEnd );
                         run.Style( MatchNormalStyleInfo, LocationStyleInfo );
                         plain_text += index_and_length;
@@ -628,7 +669,7 @@ namespace RegExpressWPFNET
                 if( max_number_achieved ) break;
                 if( cnc.IsCancellationRequested ) break;
 
-                plain_text = "".PadRight( left_width + left_space_for_match + MaxMatchLength + right_space_for_match + 20, 'W' );
+
 
                 FormattedText ft = new(
                     plain_text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
@@ -728,7 +769,6 @@ namespace RegExpressWPFNET
                         // (NOTE. Overlaps of groups are possible in this example: (?=(..))
 
                         Inline value_inline;
-                        Inline inl;
 
                         if( !group.Success )
                         {
@@ -770,20 +810,11 @@ namespace RegExpressWPFNET
                                 }
                             }
 
-                            if( left.Length > 0 )
-                            {
-                                (inl, _) = sibling_run_builder.Build( left, span.ContentEnd );
-                                inl.Style( GroupSiblingValueStyleInfo );
-                            }
-
-                            (value_inline, _) = match_run_builder.Build( middle, span.ContentEnd, left_space_for_match + MaxMatchLength + MaxMatchRightOutdent - left.Length );
-                            value_inline.Style( GroupValueStyleInfo, highlight_light_style );
-
-                            if( right.Length > 0 )
-                            {
-                                (inl, _) = sibling_run_builder.Build( right, span.ContentEnd, left_space_for_match + MaxMatchLength + MaxMatchRightOutdent - ( left.Length + middle.Length ) );
-                                inl.Style( GroupSiblingValueStyleInfo );
-                            }
+                            value_inline = TruncateAndRender( span,
+                                left, middle, right,
+                                max_content_chars,
+                                match_run_builder, sibling_run_builder,
+                                GroupValueStyleInfo, highlight_light_style, GroupSiblingValueStyleInfo );
                         }
 
                         if( cnc.IsCancellationRequested ) return;
@@ -792,7 +823,7 @@ namespace RegExpressWPFNET
                         {
                             if( !no_group_details )
                             {
-                                run = new Run( $"\x200E  （{group.Index}, {group.Length}）", span.ContentEnd );
+                                run = new Run( GetMatchIndexAndLengthSuffix(group.Index,group.Length), span.ContentEnd );
                                 run.Style( MatchNormalStyleInfo, LocationStyleInfo );
                             }
                         }
@@ -812,7 +843,8 @@ namespace RegExpressWPFNET
                         {
                             AppendCaptures( cnc, group_info, para, left_width, left_space_for_match,
                                 MaxMatchLeftOutdent, MaxMatchLength, MaxMatchRightOutdent,
-                                text, match, group, highlight_light_style, match_run_builder, sibling_run_builder );
+                                text, match, group, highlight_light_style, match_run_builder, sibling_run_builder,
+                                max_content_chars );
                         }
                     } );
                 }
@@ -897,7 +929,8 @@ namespace RegExpressWPFNET
         void AppendCaptures( ICancellable cnc, GroupInfo groupInfo, Paragraph para, int leftWidth, int leftSpaceForMatch,
             int MaxMatchLeftOutdent, int MaxMatchLength, int MaxMatchRightOutdent,
             string text, IMatch match, IGroup group, StyleInfo highlightStyle,
-            OutputBuilder runBuilder, OutputBuilder siblingRunBuilder )
+            OutputBuilder runBuilder, OutputBuilder siblingRunBuilder,
+            int maxContentChars )
         {
             int capture_number = -1;
             foreach( ICapture capture in group.Captures )
@@ -1004,23 +1037,14 @@ namespace RegExpressWPFNET
                         left = left.PadLeft( left_space_for_capture );
                     }
 
-                    if( left.Length > 0 )
-                    {
-                        (inline, _) = siblingRunBuilder.Build( left, span.ContentEnd );
-                        inline.Style( GroupSiblingValueStyleInfo );
-                    }
-
-                    (value_inline, _) = runBuilder.Build( middle, span.ContentEnd, leftSpaceForMatch + MaxMatchLength + MaxMatchRightOutdent - left.Length );
-                    value_inline.Style( GroupValueStyleInfo, highlightStyle );
-
-                    if( right.Length > 0 )
-                    {
-                        (inline, _) = siblingRunBuilder.Build( right, span.ContentEnd, leftSpaceForMatch + MaxMatchLength + MaxMatchRightOutdent - ( left.Length + middle.Length ) );
-                        inline.Style( GroupSiblingValueStyleInfo );
-                    }
+                    value_inline = TruncateAndRender( span,
+                        left, middle, right,
+                        maxContentChars,
+                        runBuilder, siblingRunBuilder,
+                        GroupValueStyleInfo, highlightStyle, GroupSiblingValueStyleInfo );
                 }
 
-                inline = new Run( $"\x200E  （{capture.Index}, {capture.Length}）", span.ContentEnd );
+                inline = new Run( GetMatchIndexAndLengthSuffix(capture.Index,capture.Length), span.ContentEnd );
                 inline.Style( MatchNormalStyleInfo, LocationStyleInfo );
 
                 para.Inlines.Add( span );
@@ -1032,6 +1056,61 @@ namespace RegExpressWPFNET
 
                 groupInfo.CaptureInfos.Add( capture_info );
             }
+        }
+
+        Inline TruncateAndRender(
+            Span span,
+            string left, string middle, string right,
+            int maxChars,
+            OutputBuilder valueBuilder, OutputBuilder siblingBuilder,
+            StyleInfo valueStyle, StyleInfo highlightStyle, StyleInfo siblingStyle )
+        {
+            Inline value_inline;
+
+            // Distribute available chars: prioritize middle (the actual value)
+            int len_middle = Math.Min( middle.Length, maxChars );
+            int remaining_chars = maxChars - len_middle;
+
+            int len_left = 0;
+            int len_right = 0;
+
+            if( remaining_chars > 0 )
+            {
+                int half = remaining_chars / 2;
+                len_left = Math.Min( left.Length, half );
+                len_right = Math.Min( right.Length, remaining_chars - len_left );
+
+                // If left is short, give more to right
+                if( left.Length < half )
+                {
+                    len_right = Math.Min( right.Length, remaining_chars - left.Length );
+                }
+            }
+
+            // For left context, we want to show the END of the string (closest to the match)
+            // OutputBuilder truncates from the end, so we need to substring from the right part first
+            if( left.Length > 0 && len_left > 0 )
+            {
+                string left_portion = left.Substring( left.Length - len_left );
+                Inline inline;
+                (inline, _) = siblingBuilder.Build( left_portion, span.ContentEnd, len_left );
+                inline.Style( siblingStyle );
+            }
+
+            // Middle (the actual match/group/capture value) - let OutputBuilder handle truncation
+            (value_inline, _) = valueBuilder.Build( middle, span.ContentEnd, len_middle );
+            value_inline.Style( valueStyle, highlightStyle );
+
+            // For right context, we want to show the START of the string (closest to the match)
+            // OutputBuilder naturally truncates from the end, which is what we want
+            if( right.Length > 0 && len_right > 0 )
+            {
+                Inline inline;
+                (inline, _) = siblingBuilder.Build( right, span.ContentEnd, len_right );
+                inline.Style( siblingStyle );
+            }
+
+            return value_inline;
         }
 
 

--- a/RegExpressWPFNET/RegExpressWPFNET/UCMatches.xaml.cs
+++ b/RegExpressWPFNET/RegExpressWPFNET/UCMatches.xaml.cs
@@ -114,7 +114,7 @@ namespace RegExpressWPFNET
             ExternalUnderliningLoop = new ResumableLoop( "Matches External Underline", ExternalUnderliningThreadProc, 333, 555 );
 
 
-            pnlDebug.Visibility = Visibility.Collapsed;
+            pnlDebug.Visibility = InternalConfig.SHOW_DEBUG_BUTTONS ?  Visibility.Visible :  Visibility.Collapsed;
 #if !DEBUG
 			pnlDebug.Visibility = Visibility.Collapsed;
 #endif

--- a/RegExpressWPFNET/RegExpressWPFNET/app.manifest
+++ b/RegExpressWPFNET/RegExpressWPFNET/app.manifest
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+			<longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+		</windowsSettings>
+	</application>
+
+
+
+	<!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  
+
+</assembly>

--- a/RegExpressWPFNET/RegexEngines/Ada/AdaPlugin/AdaPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Ada/AdaPlugin/AdaPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Ada/AdaPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Ada/AdaPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace AdaPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -149,7 +150,8 @@ namespace AdaPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Boost/BoostPlugin/BoostPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Boost/BoostPlugin/BoostPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Boost/BoostPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Boost/BoostPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace BoostPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch(Exception ex)
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -169,7 +170,8 @@ namespace BoostPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/CompileTimeRegex/CompileTimeRegexPlugin/CompileTimeRegexPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/CompileTimeRegex/CompileTimeRegexPlugin/CompileTimeRegexPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/CompileTimeRegex/CompileTimeRegexPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/CompileTimeRegex/CompileTimeRegexPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace CompileTimeRegexPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -148,7 +149,8 @@ namespace CompileTimeRegexPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/CppBuilder/CppBuilderPlugin/CppBuilderPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/CppBuilder/CppBuilderPlugin/CppBuilderPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/CppBuilder/CppBuilderPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/CppBuilder/CppBuilderPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace CppBuilderPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch (Exception ex)
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -152,7 +153,8 @@ namespace CppBuilderPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/D/DPlugin/DPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/D/DPlugin/DPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/D/DPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/D/DPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace DPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch (Exception ex)
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -154,7 +155,8 @@ namespace DPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/DotNET9/DotNET9Plugin/DotNET9Plugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/DotNET9/DotNET9Plugin/DotNET9Plugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/DotNET9/DotNET9Plugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/DotNET9/DotNET9Plugin/Engine.cs
@@ -91,10 +91,11 @@ namespace DotNET8Plugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch (Exception ex)
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -151,7 +152,8 @@ namespace DotNET8Plugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/DotNET9/DotNET9Worker/DotNET9Worker.csproj
+++ b/RegExpressWPFNET/RegexEngines/DotNET9/DotNET9Worker/DotNET9Worker.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkPlugin/DotNETFrameworkPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkPlugin/DotNETFrameworkPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace DotNETFrameworkPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch (Exception ex)
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -151,7 +152,8 @@ namespace DotNETFrameworkPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkPlugin/Matcher.cs
+++ b/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkPlugin/Matcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -102,7 +103,7 @@ namespace DotNETFrameworkPlugin
 
             if( !ph.Start( cnc ) ) return null;
 
-            if( !string.IsNullOrWhiteSpace( ph.Error ) ) throw new Exception( ph.Error );
+            if( !string.IsNullOrWhiteSpace( ph.Error ) ) throw new VersionNotFoundException( ph.Error );
 
             VersionResponse response = JsonSerializer.Deserialize<VersionResponse>( ph.OutputStream )!;
 

--- a/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkWorker/App.config
+++ b/RegExpressWPFNET/RegexEngines/DotNETFramework4_8/DotNETFrameworkWorker/App.config
@@ -37,10 +37,6 @@
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace FortranPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch (Exception ex)
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -163,7 +164,8 @@ namespace FortranPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                        throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/FortranPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/FortranPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/MatcherForgex.cs
+++ b/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/MatcherForgex.cs
@@ -89,7 +89,7 @@ namespace FortranPlugin
                 if( !string.IsNullOrWhiteSpace( line ) )
                 {
                     // invalid line
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    InternalConfig.HandleOtherCriticalError("Invalid Line");
                 }
 #endif
             }

--- a/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/MatcherRegexJeyemhex.cs
+++ b/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/MatcherRegexJeyemhex.cs
@@ -90,7 +90,7 @@ namespace FortranPlugin
                 if( !string.IsNullOrWhiteSpace( line ) )
                 {
                     // invalid line
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    InternalConfig.HandleOtherCriticalError("Invalid Line");
                 }
 #endif
             }

--- a/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/MatcherRegexPerazz.cs
+++ b/RegExpressWPFNET/RegexEngines/Fortran/FortranPlugin/MatcherRegexPerazz.cs
@@ -90,7 +90,7 @@ namespace FortranPlugin
                 if( !string.IsNullOrWhiteSpace( line ) )
                 {
                     // invalid line
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    InternalConfig.HandleOtherCriticalError("Invalid Line");
                 }
 #endif
             }

--- a/RegExpressWPFNET/RegexEngines/Hyperscan/HyperscanPlugin/ChimeraEngine.cs
+++ b/RegExpressWPFNET/RegexEngines/Hyperscan/HyperscanPlugin/ChimeraEngine.cs
@@ -92,10 +92,11 @@ namespace HyperscanPlugin
                 {
                     Options = JsonSerializer.Deserialize<ChimeraOptions>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new ChimeraOptions( );
                 }
@@ -153,7 +154,9 @@ namespace HyperscanPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
+
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Hyperscan/HyperscanPlugin/HyperscanEngine.cs
+++ b/RegExpressWPFNET/RegexEngines/Hyperscan/HyperscanPlugin/HyperscanEngine.cs
@@ -92,10 +92,11 @@ namespace HyperscanPlugin
                 {
                     Options = JsonSerializer.Deserialize<HyperscanOptions>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new HyperscanOptions( );
                 }
@@ -156,7 +157,8 @@ namespace HyperscanPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Hyperscan/HyperscanPlugin/HyperscanPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Hyperscan/HyperscanPlugin/HyperscanPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/ICU/ICUPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/ICU/ICUPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace ICUPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -157,7 +158,8 @@ namespace ICUPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/ICU/ICUPlugin/ICUPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/ICU/ICUPlugin/ICUPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Java/JavaPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Java/JavaPlugin/Engine.cs
@@ -100,10 +100,11 @@ namespace JavaPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -171,7 +172,8 @@ namespace JavaPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Java/JavaPlugin/JavaPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Java/JavaPlugin/JavaPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Java/JavaPlugin/Matcher.cs
+++ b/RegExpressWPFNET/RegexEngines/Java/JavaPlugin/Matcher.cs
@@ -191,7 +191,7 @@ namespace JavaPlugin
                 if( !string.IsNullOrWhiteSpace( line ) )
                 {
                     // invalid line
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    InternalConfig.HandleOtherCriticalError("Invalid Line");
                 }
 #endif
             }
@@ -293,7 +293,8 @@ namespace JavaPlugin
                         catch( Exception exc )
                         {
                             _ = exc;
-                            if( Debugger.IsAttached ) Debugger.Break( );
+                            if (InternalConfig.HandleException( exc ))
+                                throw;
 
                             // ignore
                         }
@@ -304,7 +305,8 @@ namespace JavaPlugin
                 catch( Exception exc )
                 {
                     _ = exc;
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( exc ))
+                        throw;
 
                     JrePath = null;
                 }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/Engine.cs
@@ -105,10 +105,11 @@ namespace JavaScriptPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/JavaScriptPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/JavaScriptPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherBun.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherBun.cs
@@ -159,7 +159,8 @@ namespace JavaScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }
@@ -229,7 +230,8 @@ namespace JavaScriptPlugin
                         catch( Exception exc )
                         {
                             _ = exc;
-                            if( Debugger.IsAttached ) Debugger.Break( );
+                            if (InternalConfig.HandleException( exc ))
+                                throw;
 
                             // ignore
                         }
@@ -240,7 +242,8 @@ namespace JavaScriptPlugin
                 catch( Exception exc )
                 {
                     _ = exc;
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( exc ))
+                        throw;
 
                     TempFolder = null;
                 }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherNodeJs.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherNodeJs.cs
@@ -169,7 +169,8 @@ namespace JavaScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }
@@ -229,7 +230,8 @@ namespace JavaScriptPlugin
                         catch( Exception exc )
                         {
                             _ = exc;
-                            if( Debugger.IsAttached ) Debugger.Break( );
+                            if (InternalConfig.HandleException( exc ))
+                                throw;
 
                             // ignore
                         }
@@ -240,7 +242,8 @@ namespace JavaScriptPlugin
                 catch( Exception exc )
                 {
                     _ = exc;
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( exc ))
+                        throw;
 
                     TempFolder = null;
                 }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherQuickJs.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherQuickJs.cs
@@ -143,7 +143,8 @@ namespace JavaScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherRE2JS.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherRE2JS.cs
@@ -158,7 +158,8 @@ namespace JavaScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherSpiderMonkey.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherSpiderMonkey.cs
@@ -164,7 +164,8 @@ namespace JavaScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }
@@ -234,7 +235,8 @@ namespace JavaScriptPlugin
                         catch( Exception exc )
                         {
                             _ = exc;
-                            if( Debugger.IsAttached ) Debugger.Break( );
+                            if (InternalConfig.HandleException( exc ))
+                                throw;
 
                             // ignore
                         }
@@ -245,7 +247,8 @@ namespace JavaScriptPlugin
                 catch( Exception exc )
                 {
                     _ = exc;
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( exc ))
+                        throw;
 
                     TempFolder = null;
                 }

--- a/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherWebView2.cs
+++ b/RegExpressWPFNET/RegexEngines/JavaScript/JavaScriptPlugin/MatcherWebView2.cs
@@ -174,7 +174,8 @@ namespace JavaScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Oniguruma/OnigurumaPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Oniguruma/OnigurumaPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace OnigurumaPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -248,7 +249,8 @@ namespace OnigurumaPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }
@@ -267,7 +269,8 @@ namespace OnigurumaPlugin
             {
                 _ = exc;
 
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return default;
             }

--- a/RegExpressWPFNET/RegexEngines/Oniguruma/OnigurumaPlugin/OnigurumaPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Oniguruma/OnigurumaPlugin/OnigurumaPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/PCRE2/PCRE2Plugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/PCRE2/PCRE2Plugin/Engine.cs
@@ -92,10 +92,11 @@ namespace PCRE2Plugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -173,7 +174,8 @@ namespace PCRE2Plugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/PCRE2/PCRE2Plugin/PCRE2Plugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/PCRE2/PCRE2Plugin/PCRE2Plugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Perl/PerlPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Perl/PerlPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace PerlPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -154,7 +155,8 @@ namespace PerlPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Perl/PerlPlugin/Matcher.cs
+++ b/RegExpressWPFNET/RegexEngines/Perl/PerlPlugin/Matcher.cs
@@ -145,7 +145,7 @@ namespace PerlPlugin
                     }
                     else
                     {
-                        if( Debugger.IsAttached ) Debugger.Break( );
+                        InternalConfig.HandleOtherCriticalError("No Match");
                         // ignore
                     }
                 }

--- a/RegExpressWPFNET/RegexEngines/Perl/PerlPlugin/PerlPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Perl/PerlPlugin/PerlPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/Python/PythonPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Python/PythonPlugin/Engine.cs
@@ -95,10 +95,11 @@ namespace PythonPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -165,7 +166,8 @@ namespace PythonPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Python/PythonPlugin/PythonPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Python/PythonPlugin/PythonPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Qt/QtPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Qt/QtPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace QtPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -152,7 +153,8 @@ namespace QtPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Qt/QtPlugin/QtPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Qt/QtPlugin/QtPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/RE2/RE2Plugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/RE2/RE2Plugin/Engine.cs
@@ -92,10 +92,11 @@ namespace RE2Plugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -153,7 +154,8 @@ namespace RE2Plugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/RE2/RE2Plugin/RE2Plugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/RE2/RE2Plugin/RE2Plugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Rust/RustPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Rust/RustPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace RustPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -169,7 +170,8 @@ namespace RustPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/Rust/RustPlugin/RustPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Rust/RustPlugin/RustPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/Std/StdPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/Std/StdPlugin/Engine.cs
@@ -90,10 +90,11 @@ namespace StdPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }

--- a/RegExpressWPFNET/RegexEngines/Std/StdPlugin/StdPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/Std/StdPlugin/StdPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/RegexEngines/SubReg/SubRegPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/SubReg/SubRegPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace SubRegPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -152,7 +153,8 @@ namespace SubRegPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/SubReg/SubRegPlugin/SubRegPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/SubReg/SubRegPlugin/SubRegPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/TRE/TREPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/TRE/TREPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace TREPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -159,7 +160,8 @@ namespace TREPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/TRE/TREPlugin/TREPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/TRE/TREPlugin/TREPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/TinyRegexC/TinyRegexCPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/TinyRegexC/TinyRegexCPlugin/Engine.cs
@@ -92,10 +92,11 @@ namespace TinyRegexCPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -150,7 +151,8 @@ namespace TinyRegexCPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/TinyRegexC/TinyRegexCPlugin/TinyRegexCPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/TinyRegexC/TinyRegexCPlugin/TinyRegexCPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/RegExpressWPFNET/RegexEngines/VBScript/VBScriptPlugin/Engine.cs
+++ b/RegExpressWPFNET/RegexEngines/VBScript/VBScriptPlugin/Engine.cs
@@ -91,10 +91,11 @@ namespace VBScriptPlugin
                 {
                     Options = JsonSerializer.Deserialize<Options>( json, JsonUtilities.JsonOptions )!;
                 }
-                catch
+                catch( Exception ex )
                 {
                     // ignore versioning errors, for example
-                    if( Debugger.IsAttached ) Debugger.Break( );
+                    if (InternalConfig.HandleException( ex ))
+                        throw;
 
                     Options = new Options( );
                 }
@@ -151,7 +152,8 @@ namespace VBScriptPlugin
             catch( Exception exc )
             {
                 _ = exc;
-                if( Debugger.IsAttached ) Debugger.Break( );
+                if (InternalConfig.HandleException( exc ))
+                    throw;
 
                 return null;
             }

--- a/RegExpressWPFNET/RegexEngines/VBScript/VBScriptPlugin/VBScriptPlugin.csproj
+++ b/RegExpressWPFNET/RegexEngines/VBScript/VBScriptPlugin/VBScriptPlugin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
         <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/RegExpressWPFNET/Tools/ExportFeatureMatrix/ExportFeatureMatrix.csproj
+++ b/RegExpressWPFNET/Tools/ExportFeatureMatrix/ExportFeatureMatrix.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
actual differences: https://github.com/mitchcapper/RegExpress/compare/ai_assist...more_improvements

Main Features:
- Biggest add in the new "Inspect" or scope option.  Next to each match/group/capture is a magnifier clicking this opens a new tab with all the same settings and the text set to just the value (the match/group or capture text it is next to).  Idea being if you have a regex to extract all the movies from a listing you can then scope to the per-movie entry to create a regex quickly to get the details from it
- When we switched to the more modern UI I think I broke the proper wrap functionality this fixes it.  The original also didn't account for \r/\n vs \r\n   for width calculations and this takes care of that (also any other specials that take up more than one char were always counted as one for total length calc).
- The original improvements added ability to limit the engines loaded at startup, this allows specifying more than one
- Use Environment.Exit to bail out if an existing process was there.   Calling Shutdown() still called the mainwindow constructor which in turn resulted in us trying to save session state before we loaded it.  This would essentially discard the saved session state.  This wasn't noticed because the existing process would just write it again before it exited.   Instead Environment.Exit avoids constructing MainWindow at all.

In terms of merging officially 
improvements-> ai_assist -> this PR -> html agility

I could likely manually merge these into the improvements branches just not quite as frictionless.   If any commits/items are not merged I can rebase as needed.